### PR TITLE
Easy embed coloring

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -93,7 +93,15 @@ class Message extends Jsonable
         return $this->timestamp;
     }
 
-    public function setColor(string $color)
+    public function setColorRGB(int $red, int $green, int $blue)
+    {
+        $this->color = ($red << 16) + ($green << 8) + $blue;
+    }
+
+    /**
+     * Set the 24-bit RGB value of a color
+     */
+    public function setColor(int $color)
     {
         $this->color = $color;
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -99,7 +99,7 @@ class Message extends Jsonable
     }
 
     /**
-     * Set the 24-bit RGB value of a color
+     * Set the 24-bit RGB value of a color.
      */
     public function setColor(int $color)
     {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -79,12 +79,20 @@ class MessageTest extends TestCase
     /** @test */
     public function canProvideColor()
     {
-        $this->message->setColor($color = uniqid());
+        $this->message->setColor($color = time());
 
         $this->assertEquals($color, $this->message->color());
 
         $this->assertArrayHasKey('color', $this->message->jsonSerialize()['embed']);
         $this->assertEquals($color, $this->message->jsonSerialize()['embed']['color']);
+    }
+
+    /** @test */
+    public function canSetColorBasedOnRGB()
+    {
+        $this->message->setColorRGB(62, 143, 64);
+
+        $this->assertEquals(4099904, $this->message->color());
     }
 
     /** @test */


### PR DESCRIPTION
Since Discord expects colors to be defined in 24-bit RGB values, this PR provides the ability to set with a standard RGB value.